### PR TITLE
Added the ability to set the cycle duration from your config.ru configuration block

### DIFF
--- a/lib/sinatra/cyclist.rb
+++ b/lib/sinatra/cyclist.rb
@@ -6,6 +6,7 @@ module Sinatra
     def self.registered(app)
       app.enable :sessions
       app.set :routes_to_cycle_through, []
+      app.set :cycle_duration, 3
 
       app.get "/_cycle" do
         return if settings.routes_to_cycle_through.empty?
@@ -16,7 +17,11 @@ module Sinatra
         number_of_routes = settings.routes_to_cycle_through.length
         page = settings.routes_to_cycle_through[session[:_cycle_page_index] % number_of_routes]
 
-        session[:_cycle_duration] = params[:duration] || 3
+        if params[:duration]
+          session[:_cycle_duration] = params[:duration]
+        end
+
+        session[:_cycle_duration] ||= settings.cycle_duration
 
         session[:_cycle] = true
 


### PR DESCRIPTION
The default is still 3 seconds. Whenever the `duration` parameter is set, it will be saved to the session and it will be used as the cycle duration.

If you would like the default to be 30 seconds, you can override this behavior by specifying the following in your Dashing config.ru:

``` ruby
configure do
  set :auth_token, 'YOUR_AUTH_TOKEN'
  set :routes_to_cycle_through, [:dashboard_1, :dashboard_2, :dashboard_3]
  set :cycle_duration, 30
  ...
```

You'll still be able to set the duration with the GET parameter. Once that's set, it will keep that value during the session.
