### PR TITLE
Ensure /_cycle passes any other params on redirect

### DIFF
--- a/lib/sinatra/cyclist.rb
+++ b/lib/sinatra/cyclist.rb
@@ -23,9 +23,12 @@ module Sinatra
 
         session[:_cycle_duration] ||= settings.cycle_duration
 
+        session[:_cycle_redirect_params] ||= params.reject { |p| p == :duration }
+        query = session[:_cycle_redirect_params].map { |k,v| "#{k}=#{v}" }.join('&')
+
         session[:_cycle] = true
 
-        redirect "/#{page}"
+        redirect "/#{page}#{query.empty? ? '' : "?#{query}"}"
       end
 
       app.before do


### PR DESCRIPTION
I want to be able to pass query params to a dashboard so I can for example modify the layout based on the device (rather than have a separate dashboard for each one). However, cycling through the boards using this gem - which is really useful - breaks this since params are not persisted across each request.

This change fixes that so that for example `/_cycle?screen=tv` will pass the screen param in each dashboard redirect.
